### PR TITLE
Corrected a typo on line 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ const wit = new Wit('<YOUR-SERVER-ACCESS-TOKEN>')
 
 ## Message
 ```Javascript
-wit.message('Wake me up when septembre end!').then((intent) => {
+wit.message('Wake me up when september end!').then((intent) => {
   // intent is an instance of Entity
   console.log(intent)
   // We can call Entity methods cuch as `.maxConfidence()`


### PR DESCRIPTION
'september' was spelled 'septembre'. Just corrected that typo in this commit