### PR TITLE
Add capability to add/remove multiple samples

### DIFF
--- a/src/Sample.js
+++ b/src/Sample.js
@@ -13,12 +13,9 @@ const actions = function(id) {
 
 module.exports = function (request) {
   return {
-    add: function(text, entities) {
+    add: function (...args) {
       let payload = actions().add
-      let body = [{
-        text,
-        entities
-      }]
+      let body = Array.isArray(args[0]) ? args[0] : [{text: args[0], entities: args[1]}]
       return new Promise((resolve, reject) => {
         try {
           payload.body = JSON.stringify(body)
@@ -33,11 +30,9 @@ module.exports = function (request) {
         })
       })
     },
-    delete: function (text) {
+    delete: function (...args) {
       let payload = actions().delete
-      let body = [{
-        text
-      }]
+      let body = Array.isArray(args[0]) ? args[0] : [{text: args[0]}]
       return new Promise((resolve, reject) => {
         try {
           payload.body = JSON.stringify(body)


### PR DESCRIPTION
This will allow users to send either one sample or multiple samples. 
```Javascript
wit.train(samples) // instead of wit.train(text, entities)
wit.forget(samples) // instead of wit.forget(text)
```
Below an example: 
```Javascript
wit.train([{
  text: 'Hi',
  entities: [ {
      entity: "intent",
      value: "greeting"
   }]
}, {
  text: 'Hello',
  entities: [ {
      entity: "intent",
      value: "greeting"
   }]
}]).then(res => {
  console.log(res)
  // { sent: true, n: 1 }
})
```